### PR TITLE
installer: do not install recommends

### DIFF
--- a/nvidia-docker-installer.sh
+++ b/nvidia-docker-installer.sh
@@ -21,8 +21,10 @@ RETRY_COUNT=5
 download_kernel_src() {
   echo "Downloading kernel sources..."
   apt-get update
-  apt-get install -y linux-headers-$(uname -r)
-  apt-get install -y gcc libc-dev
+  apt-get install --no-install-recommends -y \
+    gcc \
+    libc-dev \
+    linux-headers-$(uname -r)
   echo "Downloading kernel sources... DONE."
 }
 
@@ -67,7 +69,9 @@ install_nvidia_docker2() {
   distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
   curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | tee /etc/apt/sources.list.d/nvidia-docker.list
   apt-get update
-  apt-get install -y nvidia-docker2=2.0.3+docker18.06.1-1 nvidia-container-runtime=2.0.0+docker18.06.1-1
+  apt-get install --no-install-recommends -y \
+    nvidia-docker2=2.0.3+docker18.06.1-1 \
+    nvidia-container-runtime=2.0.0+docker18.06.1-1
 }
 
 set_nvidia_container_runtime() {


### PR DESCRIPTION
Debian recommends man pages for kernel sources / gcc, not really needed on server.

This PR doesn't really add much value, tbh, but why not :man_shrugging: 